### PR TITLE
Remove Subject Requirement

### DIFF
--- a/text.js
+++ b/text.js
@@ -7,7 +7,7 @@ var debugEnabled = false;
 var default_options = {
   fromAddr: 'textbelt@me.com',
   fromName: 'Textbelt',
-  subject:  '/',
+  subject:  '',
   region:   'us'
 }
 


### PR DESCRIPTION
By defaulting subject to '/' you cause any text sent with no subject to be preceded by "(/)", an unnecessary and unattractive standard. Setting this default to an empty string translates to no subject if the user doesn't specify a subject.
