### PR TITLE
Update providers.json

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -12,7 +12,8 @@
     "%s@tmomail.net",
     "%s@txt.att.net",
     "%s@txt.windmobile.ca",
-    "%s@vtext.com"
+    "%s@vtext.com",
+    "%s"
   ],
 
   "canada": [
@@ -69,7 +70,8 @@
     "%s@utext.com",
     "%s@vmobile.ca",
     "%s@vmobl.com",
-    "%s@vtext.com"
+    "%s@vtext.com",
+    "%s"
   ],
 
   "intl": [
@@ -146,6 +148,7 @@
     "%s@text.simplefreedom.net",
     "%s@timnet.com",
     "%s@vodafone.net",
-    "%s@wyndtell.com"
+    "%s@wyndtell.com",
+    "%s"
   ]
 }


### PR DESCRIPTION
Added ability to input direct email for "to" number, allowing user to define carrier themselves or send text as an email by including possibility of no carrier specific suffix.

Unrelated, the "from" email address seems to receive an email on success claiming failure to send message to "<from>@email.uscc.net", which is the first carrier provided on the US list. I would suggest looking into how to either remove that email, possibly adding a confirmation email updating the owner that their email address was used.
