### PR TITLE
Update providers.json

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -1,5 +1,6 @@
 {
   "us": [
+    "%s",
     "%s@email.uscc.net",
     "%s@message.alltel.com",
     "%s@messaging.sprintpcs.com",
@@ -16,6 +17,7 @@
   ],
 
   "canada": [
+    "%s",
     "%s@blueskyfrog.com",
     "%s@bplmobile.com",
     "%s@cellularonewest.com",
@@ -73,6 +75,7 @@
   ],
 
   "intl": [
+    "%s",
     "%s@airtelchennai.com",
     "%s@airtelkol.com",
     "%s@airtelmail.com",


### PR DESCRIPTION
Added ability to input direct email for "to" number, allowing user to define carrier themselves or send text as an email by including possibility of no carrier specific suffix.

Unrelated, the "from" email address seems to receive an email on success claiming failure to send message to "@email.uscc.net", which is the first carrier provided on the US list. I would suggest looking into how to either remove that email or possibly add a confirmation email updating the owner that their email address was used.
